### PR TITLE
Changed the bundle identifier to a unique name to allow for building

### DIFF
--- a/lumi/src-tauri/tauri.conf.json
+++ b/lumi/src-tauri/tauri.conf.json
@@ -29,7 +29,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "com.tauri.dev",
+      "identifier": "com.app.Lumi",
       "longDescription": "",
       "macOS": {
         "entitlements": null,


### PR DESCRIPTION
Changed the bundle identifier to a unique name to allow for building.

npm run tauri build now succeeds (ran on windows device)